### PR TITLE
Version Bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "prod": "brunch build --production"
   },
   "dependencies": {
-    "react": "~15.2.1",
-    "react-dom": "~15.2.1"
+    "react": "~15.3.0",
+    "react-dom": "~15.3.0"
   },
   "devDependencies": {
     "auto-reload-brunch": "^2.0.0",


### PR DESCRIPTION
Bump React version to `15.3.0`

Brunch is now at `2.8.2`. Our specification `^2.4.0` includes this just fine though. Should we update it, or just leave it? Not sure what the convention is.
